### PR TITLE
Add dummy credentials to be able to build the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*credentials*
 .pioenvs
 .piolibdeps
 .clang_complete

--- a/lib/grbl/src/credentials.hpp
+++ b/lib/grbl/src/credentials.hpp
@@ -1,0 +1,3 @@
+#define WIFI_HOSTNAME "printer"
+#define WIFI_SSID "Welcome"
+#define WIFI_PASSWORD "CoolToSeeYou"

--- a/lib/grbl/src/credentials.hpp
+++ b/lib/grbl/src/credentials.hpp
@@ -1,3 +1,8 @@
-#define WIFI_HOSTNAME "printer"
-#define WIFI_SSID "Welcome"
-#define WIFI_PASSWORD "CoolToSeeYou"
+#ifndef credentials_h
+#define credentials_h
+
+#define WIFI_SSID "Whatever"
+#define WIFI_PASSWORD "mydummypassword"
+#define WIFI_HOSTNAME "grblesp"
+
+#endif


### PR DESCRIPTION
I do understand the motivation to ignore the credentials in order to not commit them, but in this case the project cant be built locally.

Maybe adding this file to **.git/info/exclude** locally as described here: https://help.github.com/en/github/using-git/ignoring-files is a solution. 