### PR TITLE
Enable interrupts after the task switch flag was cleared

### DIFF
--- a/lib/grbl/src/nuts_bolts.cpp
+++ b/lib/grbl/src/nuts_bolts.cpp
@@ -112,6 +112,7 @@ void delay_sec(float seconds, uint8_t mode)
 {
  	uint16_t i = ceil(1000/DWELL_TIME_STEP*seconds);
 	while (i-- > 0) {
+    ESP.wdtFeed();
 		if (sys.abort) { return; }
 		if (mode == DELAY_MODE_DWELL) {
 			protocol_execute_realtime();

--- a/lib/grbl/src/protocol.cpp
+++ b/lib/grbl/src/protocol.cpp
@@ -78,6 +78,7 @@ void protocol_main_loop()
     for (client = 1; client <= CLIENT_COUNT; client++)
     {
       while((c = serial_read(client)) != SERIAL_NO_DATA) {
+        ESP.wdtFeed();
         delay(0);
         if ((c == '\n') || (c == '\r')) { // End of line reached
           protocol_execute_realtime(); // Runtime command check point.
@@ -631,7 +632,10 @@ static void protocol_exec_rt_suspend()
             spindle_set_state(SPINDLE_DISABLE,0.0); // De-energize
             coolant_set_state(COOLANT_DISABLE); // De-energize
             st_go_idle(); // Disable steppers
-            while (!(sys.abort)) { delay(0); protocol_exec_rt_system(); } // Do nothing until reset.
+            while (!(sys.abort)) { 
+              delay(0); 
+              protocol_exec_rt_system(); 
+              } // Do nothing until reset.
             return; // Abort received. Return to re-initialize.
           }
 

--- a/lib/grbl/src/system.cpp
+++ b/lib/grbl/src/system.cpp
@@ -395,6 +395,7 @@ void system_clear_exec_state_flag(uint8_t mask) {
   cli();
   sys_rt_exec_state &= ~(mask);
   restore_SREG(sreg);
+  sei();
 }
 
 void system_set_exec_alarm(uint8_t code) {
@@ -409,6 +410,7 @@ void system_clear_exec_alarm() {
   cli();
   sys_rt_exec_alarm = 0;
   restore_SREG(sreg);
+    sei();
 }
 
 void system_set_exec_motion_override_flag(uint8_t mask) {
@@ -430,6 +432,7 @@ void system_clear_exec_motion_overrides() {
   cli();
   sys_rt_exec_motion_override = 0;
   restore_SREG(sreg);
+    sei();
 }
 
 void system_clear_exec_accessory_overrides() {
@@ -437,4 +440,5 @@ void system_clear_exec_accessory_overrides() {
   cli();
   sys_rt_exec_accessory_override = 0;
   restore_SREG(sreg);
+    sei();
 }


### PR DESCRIPTION
Grbl uses flags to switch tasks and to set them it disables the interrupts with `cli()`, sets the flag then calls `restore_SREG()` which is defined as `#define restore_SREG(state) xt_wsr_ps(state); sei(); // restore the state (uint32_t)`. It seems that the macro definition is wrong because after adding an additional call to sei(); in the flag clearing functions - the nodemcu doesn't software reset. 